### PR TITLE
Logic to support `@save` annotation/tag in JS Doc comments to preserve user changes when re-generating code from OpenAPI Documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "prettier": "3.2.5",
         "semver": "^7.5.4",
         "swagger-typescript-api": "^13.0.3",
+        "ts-morph": "^22.0.0",
         "yeoman-generator": "^5.10.0"
       },
       "bin": {
@@ -795,6 +796,53 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
+      "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.3",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2129,6 +2177,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.1.tgz",
+      "integrity": "sha512-c5or4P6erEA69TxaxTNcHUNcIn+oyxSRTOWV+pSYF+z4epXqNvwvJ70XPGjPNgue83oAFAPBRQYwpAJ/Hpe/Sg=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4879,6 +4932,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6351,6 +6409,15 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
+      "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
+      "dependencies": {
+        "@ts-morph/common": "~0.23.0",
+        "code-block-writer": "^13.0.1"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "3.2.5",
     "semver": "^7.5.4",
     "swagger-typescript-api": "^13.0.3",
+    "ts-morph": "^22.0.0",
     "yeoman-generator": "^5.10.0"
   },
   "devDependencies": {

--- a/src/app/ts-parser/morph.test.ts
+++ b/src/app/ts-parser/morph.test.ts
@@ -2,7 +2,6 @@ import * as morph from "./morph";
 import * as ts from "ts-morph";
 import * as assert from "assert";
 import * as fs from "fs";
-import { mergeTsSources } from ".";
 import path from "path";
 import * as prettier from "prettier";
 

--- a/src/app/ts-parser/morph.test.ts
+++ b/src/app/ts-parser/morph.test.ts
@@ -1,0 +1,66 @@
+import * as morph from "./morph";
+import * as ts from "ts-morph";
+import * as assert from "assert";
+import * as fs from "fs";
+import { mergeTsSources } from ".";
+import path from "path";
+import * as prettier from "prettier";
+
+type TestCase = {
+  name: string;
+  directory: string;
+  staleSourceFile?: ts.SourceFile;
+  freshSourceFile?: ts.SourceFile;
+  mergedFileContents?: string;
+};
+
+const tests: TestCase[] = [
+  {
+    name: "Add and Replace",
+    directory: "./testdata/morph-tests/add-and-replace/",
+  },
+  {
+    name: "No change",
+    directory: "./testdata/morph-tests/no-change/",
+  },
+];
+
+describe("Preserve Saved Functions", async () => {
+  for (const testCase of tests) {
+    before(function () {
+      testCase.directory = path.resolve(__dirname, testCase.directory);
+      const staleProject = new ts.Project();
+      testCase.staleSourceFile = staleProject.addSourceFileAtPath(
+        path.resolve(testCase.directory, "stale.ts"),
+      );
+
+      const freshProject = new ts.Project();
+      testCase.freshSourceFile = freshProject.addSourceFileAtPath(
+        path.resolve(testCase.directory, "fresh.ts"),
+      );
+
+      testCase.mergedFileContents = fs
+        .readFileSync(path.resolve(testCase.directory, "merged.ts"))
+        .toString();
+    });
+
+    it(testCase.name, async () => {
+      morph.preserveSavedFunctions(
+        testCase.staleSourceFile!,
+        testCase.freshSourceFile!,
+      );
+
+      const gotStr = await prettier.format(
+        testCase.freshSourceFile?.getFullText()!,
+        {
+          parser: "typescript",
+        },
+      );
+
+      assert.equal(testCase.mergedFileContents, gotStr);
+
+      // uncomment to update merged golden file
+      // fs.writeFileSync(path.resolve(testCase.directory, "merged.ts"), gotStr);
+    });
+  }
+});

--- a/src/app/ts-parser/morph.ts
+++ b/src/app/ts-parser/morph.ts
@@ -1,0 +1,38 @@
+/**
+ * responsible for manipulating the TS AST
+ */
+
+import * as tsMorph from "ts-morph";
+import * as walk from "./walk";
+
+/**
+ * this function preserves @save functions from a stale source file to a new/fresh source file
+ * @param staleTsSourceFile the old TS source, which has the @save functions that should be preserved
+ * @param freshTsSourceFile the new TS source, to which the @save functions will copied over to
+ */
+export function preserveSavedFunctions(
+  staleTsSourceFile: tsMorph.SourceFile,
+  freshTsSourceFile: tsMorph.SourceFile,
+) {
+  const staleSourceFunctions =
+    walk.getFunctionsWithJSDocTags(staleTsSourceFile);
+  const freshSourceFunctions =
+    walk.getFunctionsWithJSDocTags(freshTsSourceFile);
+
+  staleSourceFunctions.forEach((value, key) => {
+    if (!walk.isSavedFunction(value)) {
+      return;
+    }
+
+    // case 1: @save function exists in the fresh source file
+    if (freshSourceFunctions.has(key)) {
+      // in this case, the function should be replaced with the stale function
+      const freshFunction = freshSourceFunctions.get(key);
+      freshFunction?.function.replaceWithText(value.function.getFullText());
+    } else {
+      // case 2: @save function does not exist in the new/fresh ts source file
+      // in this case, we add the @save function to the fresh ts source file
+      freshTsSourceFile.addStatements(value.function.getFullText());
+    }
+  });
+}

--- a/src/app/ts-parser/testdata/morph-tests/add-and-replace/fresh.ts
+++ b/src/app/ts-parser/testdata/morph-tests/add-and-replace/fresh.ts
@@ -1,0 +1,13 @@
+/**
+ * a function that multiplies two numbers
+ */
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+
+/**
+ * This function prints the double value of a given number
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${multiply(2, x)}`);
+}

--- a/src/app/ts-parser/testdata/morph-tests/add-and-replace/merged.ts
+++ b/src/app/ts-parser/testdata/morph-tests/add-and-replace/merged.ts
@@ -1,0 +1,21 @@
+/**
+ * a function that multiplies two numbers
+ */
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+
+/**
+ * This function prints the double value of a given number
+ * @save
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${addition(x, x)}`);
+}
+/**
+ * addition function
+ * @save
+ */
+export function addition(a: number, b: number): number {
+  return a + b;
+}

--- a/src/app/ts-parser/testdata/morph-tests/add-and-replace/stale.ts
+++ b/src/app/ts-parser/testdata/morph-tests/add-and-replace/stale.ts
@@ -1,0 +1,22 @@
+/**
+ * addition function
+ * @save
+ */
+export function addition(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * This function prints the double value of a given number
+ * @save
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${addition(x, x)}`);
+}
+
+/**
+ * division function
+ */
+export function division(a: number, b: number) {
+  return a / b;
+}

--- a/src/app/ts-parser/testdata/morph-tests/no-change/fresh.ts
+++ b/src/app/ts-parser/testdata/morph-tests/no-change/fresh.ts
@@ -1,0 +1,13 @@
+/**
+ * a function that multiplies two numbers
+ */
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+
+/**
+ * This function prints the double value of a given number
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${multiply(2, x)}`);
+}

--- a/src/app/ts-parser/testdata/morph-tests/no-change/merged.ts
+++ b/src/app/ts-parser/testdata/morph-tests/no-change/merged.ts
@@ -1,0 +1,13 @@
+/**
+ * a function that multiplies two numbers
+ */
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+
+/**
+ * This function prints the double value of a given number
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${multiply(2, x)}`);
+}

--- a/src/app/ts-parser/testdata/morph-tests/no-change/stale.ts
+++ b/src/app/ts-parser/testdata/morph-tests/no-change/stale.ts
@@ -1,0 +1,20 @@
+/**
+ * addition function
+ */
+export function addition(a: number, b: number): number {
+  return a + b;
+}
+
+/**
+ * This function prints the double value of a given number
+ */
+export function doubleNumber(x: number) {
+  console.log(`double of ${x} is ${addition(x, x)}`);
+}
+
+/**
+ * division function
+ */
+export function division(a: number, b: number) {
+  return a / b;
+}

--- a/src/app/ts-parser/testdata/walk-tests/google-home-functions-with-tags.json
+++ b/src/app/ts-parser/testdata/walk-tests/google-home-functions-with-tags.json
@@ -1,196 +1,122 @@
 [
   {
     "functionName": "getNoticeHtmlGzLegalNotice",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postAssistantAccessibility",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getAssistantGetAlarmsandTimers",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postAssistantDeleteAlarmsandTimers",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postAssistantAlarmVolume",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postAssistantCheckReadyStatus",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postAssistantDoNotDisturb",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postAssistantNightModesettings",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postBluetoothForgetpaireddevice",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postBluetoothPairwithSpeaker",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postBluetoothChangeDiscoverability",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getBluetoothGetPairedDevices",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postBluetoothScanfordevices",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getBluetoothGetScanResults",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "getBluetoothStatus",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "getConfiguredNetworksGetSavedNetworks",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postConnectWifiConnecttoWiFiNetwork",
-    "jsDocTags": [
-      "request",
-      "allowrelaxedtypes"
-    ]
+    "jsDocTags": ["request", "allowrelaxedtypes"]
   },
   {
     "functionName": "getEurekaInfoEurekaInfo",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postForgetWifiForgetWiFiNetwork",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postGetAppDeviceIdAppDeviceId",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getIconPngChromecastIcon",
-    "jsDocTags": [
-      "request",
-      "allowrelaxedtypes",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "allowrelaxedtypes", "readonly"]
   },
   {
     "functionName": "getOfferOffer",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postRebootRebootandFactoryReset",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getScanResultsGetWiFiScanResults",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postScanWifiScanforNetworks",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postSetEurekaInfoSetEurekaInfo",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "getSupportedLocalesLocales",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "getSupportedTimezonesTimezones",
-    "jsDocTags": [
-      "request",
-      "readonly"
-    ]
+    "jsDocTags": ["request", "readonly"]
   },
   {
     "functionName": "postTestInternetDownloadSpeedTestInternetDownloadSpeed",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   },
   {
     "functionName": "postUserEqSetEqualizerValues",
-    "jsDocTags": [
-      "request"
-    ]
+    "jsDocTags": ["request"]
   }
 ]

--- a/src/app/ts-parser/testdata/walk-tests/google-home-functions-with-tags.json
+++ b/src/app/ts-parser/testdata/walk-tests/google-home-functions-with-tags.json
@@ -1,0 +1,196 @@
+[
+  {
+    "functionName": "getNoticeHtmlGzLegalNotice",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postAssistantAccessibility",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getAssistantGetAlarmsandTimers",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postAssistantDeleteAlarmsandTimers",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postAssistantAlarmVolume",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postAssistantCheckReadyStatus",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postAssistantDoNotDisturb",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postAssistantNightModesettings",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postBluetoothForgetpaireddevice",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postBluetoothPairwithSpeaker",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postBluetoothChangeDiscoverability",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getBluetoothGetPairedDevices",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postBluetoothScanfordevices",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getBluetoothGetScanResults",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "getBluetoothStatus",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "getConfiguredNetworksGetSavedNetworks",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postConnectWifiConnecttoWiFiNetwork",
+    "jsDocTags": [
+      "request",
+      "allowrelaxedtypes"
+    ]
+  },
+  {
+    "functionName": "getEurekaInfoEurekaInfo",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postForgetWifiForgetWiFiNetwork",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postGetAppDeviceIdAppDeviceId",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getIconPngChromecastIcon",
+    "jsDocTags": [
+      "request",
+      "allowrelaxedtypes",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "getOfferOffer",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postRebootRebootandFactoryReset",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getScanResultsGetWiFiScanResults",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postScanWifiScanforNetworks",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postSetEurekaInfoSetEurekaInfo",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "getSupportedLocalesLocales",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "getSupportedTimezonesTimezones",
+    "jsDocTags": [
+      "request",
+      "readonly"
+    ]
+  },
+  {
+    "functionName": "postTestInternetDownloadSpeedTestInternetDownloadSpeed",
+    "jsDocTags": [
+      "request"
+    ]
+  },
+  {
+    "functionName": "postUserEqSetEqualizerValues",
+    "jsDocTags": [
+      "request"
+    ]
+  }
+]

--- a/src/app/ts-parser/walk.test.ts
+++ b/src/app/ts-parser/walk.test.ts
@@ -1,47 +1,42 @@
 import { readFileSync, writeFileSync } from "fs";
 import path from "path";
-import * as ts from "typescript";
+import * as ts from "ts-morph";
 import * as tsWalk from "./walk";
 import * as assert from "assert";
 
 type FunctionsAndTags = {
-  functionName: string,
-  jsDocTags: string[],
-}
+  functionName: string;
+  jsDocTags: string[];
+};
 
 type TestCase = {
-  name: string,
-  goldenFile: string,
-  testFile: string,
-  testFileContents?: string,
-  goldenFileContents?: FunctionsAndTags[],
-}
+  name: string;
+  goldenFile: string;
+  testFile: string;
+  goldenFileContents?: FunctionsAndTags[];
+};
 
 const getFunctionsWithTagsTests: TestCase[] = [
   {
     name: "GoogleHome",
     testFile: "../open-api-generator/tests/golden-files/google-home",
-    goldenFile: "./testdata/walk-tests/google-home-functions-with-tags.json"
-  }
-]
+    goldenFile: "./testdata/walk-tests/google-home-functions-with-tags.json",
+  },
+];
 
-describe("Get Functions with JSDoc Tags", async() => {
+describe("Get Functions with JSDoc Tags", async () => {
   for (const testCase of getFunctionsWithTagsTests) {
-    before (function() {
+    before(function () {
       testCase.testFile = path.resolve(__dirname, testCase.testFile);
       testCase.goldenFile = path.resolve(__dirname, testCase.goldenFile);
-      testCase.testFileContents = readFileSync(testCase.testFile).toString();
-      testCase.goldenFileContents = JSON.parse(readFileSync(testCase.goldenFile).toString());
+      testCase.goldenFileContents = JSON.parse(
+        readFileSync(testCase.goldenFile).toString(),
+      );
     });
 
-    it(`${testCase.name}`, function() {
-      const tsSourceFile = ts.createSourceFile(
-        testCase.testFile,
-        testCase.testFileContents!,
-        ts.ScriptTarget.Latest,
-        true, 
-      );
-
+    it(`${testCase.name}`, function () {
+      const project = new ts.Project();
+      const tsSourceFile = project.addSourceFileAtPath(testCase.testFile);
       const gotMap = tsWalk.getFunctionsWithJSDocTags(tsSourceFile);
       const gotArray: FunctionsAndTags[] = [];
 
@@ -49,9 +44,9 @@ describe("Get Functions with JSDoc Tags", async() => {
         gotArray.push({
           functionName: key,
           jsDocTags: value.tags,
-        })
+        });
       });
-      
+
       assert.deepEqual(testCase.goldenFileContents, gotArray);
 
       // writeFileSync(testCase.goldenFile, JSON.stringify(gotArray));

--- a/src/app/ts-parser/walk.test.ts
+++ b/src/app/ts-parser/walk.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
+import * as ts from "typescript";
+import * as tsWalk from "./walk";
+import * as assert from "assert";
+
+type FunctionsAndTags = {
+  functionName: string,
+  jsDocTags: string[],
+}
+
+type TestCase = {
+  name: string,
+  goldenFile: string,
+  testFile: string,
+  testFileContents?: string,
+  goldenFileContents?: FunctionsAndTags[],
+}
+
+const getFunctionsWithTagsTests: TestCase[] = [
+  {
+    name: "GoogleHome",
+    testFile: "../open-api-generator/tests/golden-files/google-home",
+    goldenFile: "./testdata/walk-tests/google-home-functions-with-tags.json"
+  }
+]
+
+describe("Get Functions with JSDoc Tags", async() => {
+  for (const testCase of getFunctionsWithTagsTests) {
+    before (function() {
+      testCase.testFile = path.resolve(__dirname, testCase.testFile);
+      testCase.goldenFile = path.resolve(__dirname, testCase.goldenFile);
+      testCase.testFileContents = readFileSync(testCase.testFile).toString();
+      testCase.goldenFileContents = JSON.parse(readFileSync(testCase.goldenFile).toString());
+    });
+
+    it(`${testCase.name}`, function() {
+      const tsSourceFile = ts.createSourceFile(
+        testCase.testFile,
+        testCase.testFileContents!,
+        ts.ScriptTarget.Latest,
+        true, 
+      );
+
+      const gotMap = tsWalk.getFunctionsWithJSDocTags(tsSourceFile);
+      const gotArray: FunctionsAndTags[] = [];
+
+      gotMap.forEach((value, key) => {
+        gotArray.push({
+          functionName: key,
+          jsDocTags: value.tags,
+        })
+      });
+      
+      assert.deepEqual(testCase.goldenFileContents, gotArray);
+
+      // writeFileSync(testCase.goldenFile, JSON.stringify(gotArray));
+    });
+  }
+});

--- a/src/app/ts-parser/walk.ts
+++ b/src/app/ts-parser/walk.ts
@@ -1,0 +1,63 @@
+import * as ts from "typescript";
+
+export type FunctionWithTagsAsStringArray = {
+  function: ts.FunctionDeclaration,
+  tags: string[],
+}
+
+export function getFunctionsWithJSDocTags(tsSourceFile: ts.SourceFile): Map<string, FunctionWithTagsAsStringArray> {
+  const functionsWithJSDocTags = new Map<string, FunctionWithTagsAsStringArray>();
+  const allFunctions = getAllFunctions(tsSourceFile);
+  allFunctions.forEach((func) => {
+    const functionName = getFunctionName(func);
+    const allJSDocs = getAllJSDocs(func);
+    allJSDocs.forEach((jsDoc) => {
+      const tags = getAllJSDocsTagsAsStringArray(jsDoc);
+      functionsWithJSDocTags.set(functionName!, {function: func, tags: tags});
+    });
+  });
+  return functionsWithJSDocTags;
+}
+
+export function getAllFunctions(
+  tsSourceFile: ts.SourceFile,
+): ts.FunctionDeclaration[] {
+  const allFunctions: ts.FunctionDeclaration[] = [];
+  if (!tsSourceFile) {
+    return allFunctions;
+  }
+  tsSourceFile.forEachChild((node) => {
+    if (ts.isFunctionDeclaration(node)) {
+      allFunctions.push(node as ts.FunctionDeclaration);
+    }
+  });
+  return allFunctions;
+}
+
+export function getAllJSDocs(node: ts.Node) {
+  const allJSDocTags: ts.JSDoc[] = [];
+  if (!node) {
+    return allJSDocTags;
+  }
+  node.getChildren().forEach((childNode) => {
+    if (ts.isJSDoc(childNode)) {
+      allJSDocTags.push(childNode as ts.JSDoc);
+    }
+  });
+  return allJSDocTags;
+}
+
+export function getAllJSDocsTagsAsStringArray(node: ts.JSDoc) {
+  const allTags: string[] = [];
+  if (!node) {
+    return allTags;
+  }
+  node.tags?.forEach((tag) => {
+    allTags.push(tag.tagName.escapedText.toString());
+  });
+  return allTags;
+}
+
+export function getFunctionName(node: ts.FunctionDeclaration) {
+  return node.name?.escapedText;
+}

--- a/src/app/ts-parser/walk.ts
+++ b/src/app/ts-parser/walk.ts
@@ -21,10 +21,11 @@ export function getFunctionsWithJSDocTags(
   allFunctions.forEach((func) => {
     const functionName = getFunctionName(func);
     const allJSDocs = getAllJSDocs(func);
+    let tags: string[] = [];
     allJSDocs.forEach((jsDoc) => {
-      const tags = getAllJSDocsTagsAsStringArray(jsDoc);
-      functionsWithJSDocTags.set(functionName!, { function: func, tags: tags });
+      tags = getAllJSDocsTagsAsStringArray(jsDoc);
     });
+    functionsWithJSDocTags.set(functionName!, { function: func, tags: tags });
   });
   return functionsWithJSDocTags;
 }

--- a/src/app/ts-parser/walk.ts
+++ b/src/app/ts-parser/walk.ts
@@ -1,19 +1,29 @@
-import * as ts from "typescript";
+import * as ts from "ts-morph";
 
 export type FunctionWithTagsAsStringArray = {
-  function: ts.FunctionDeclaration,
-  tags: string[],
-}
+  function: ts.FunctionDeclaration;
+  tags: string[];
+};
 
-export function getFunctionsWithJSDocTags(tsSourceFile: ts.SourceFile): Map<string, FunctionWithTagsAsStringArray> {
-  const functionsWithJSDocTags = new Map<string, FunctionWithTagsAsStringArray>();
+/**
+ *
+ * @param tsSourceFile
+ * @returns map of function name to type FunctionWithTagsAsStringArray
+ */
+export function getFunctionsWithJSDocTags(
+  tsSourceFile: ts.SourceFile,
+): Map<string, FunctionWithTagsAsStringArray> {
+  const functionsWithJSDocTags = new Map<
+    string,
+    FunctionWithTagsAsStringArray
+  >();
   const allFunctions = getAllFunctions(tsSourceFile);
   allFunctions.forEach((func) => {
     const functionName = getFunctionName(func);
     const allJSDocs = getAllJSDocs(func);
     allJSDocs.forEach((jsDoc) => {
       const tags = getAllJSDocsTagsAsStringArray(jsDoc);
-      functionsWithJSDocTags.set(functionName!, {function: func, tags: tags});
+      functionsWithJSDocTags.set(functionName!, { function: func, tags: tags });
     });
   });
   return functionsWithJSDocTags;
@@ -27,7 +37,7 @@ export function getAllFunctions(
     return allFunctions;
   }
   tsSourceFile.forEachChild((node) => {
-    if (ts.isFunctionDeclaration(node)) {
+    if (ts.Node.isFunctionDeclaration(node)) {
       allFunctions.push(node as ts.FunctionDeclaration);
     }
   });
@@ -40,7 +50,7 @@ export function getAllJSDocs(node: ts.Node) {
     return allJSDocTags;
   }
   node.getChildren().forEach((childNode) => {
-    if (ts.isJSDoc(childNode)) {
+    if (ts.Node.isJSDoc(childNode)) {
       allJSDocTags.push(childNode as ts.JSDoc);
     }
   });
@@ -52,12 +62,16 @@ export function getAllJSDocsTagsAsStringArray(node: ts.JSDoc) {
   if (!node) {
     return allTags;
   }
-  node.tags?.forEach((tag) => {
-    allTags.push(tag.tagName.escapedText.toString());
+  node.getTags()?.forEach((tag) => {
+    allTags.push(tag.getTagName());
   });
   return allTags;
 }
 
 export function getFunctionName(node: ts.FunctionDeclaration) {
-  return node.name?.escapedText;
+  return node.getName();
+}
+
+export function isSavedFunction(func: FunctionWithTagsAsStringArray): boolean {
+  return func.tags.indexOf("save") > -1;
 }


### PR DESCRIPTION
## Issue
https://hasurahq.atlassian.net/browse/EDC-24

## Description
This PR adds the logic for a saving mechanism for user's changes in TS functions file. The functionality can be made clear by considering the following use case:
1. The user generates Typescript files from their OpenAPI Document
2. The user makes some changes to `functions.ts` file
3. The OpenAPI Document gets updated to reflect latest changes in the user's APIs
4. The user re-runs our codegen to regenerate Typescript files for their updated OpenAPI Document
    
    At this point, we would like to update the user's files with the updated information in OpenAPI Document, but, we would also want to preserve the changes that were made by the user in their `functions.ts` file in *step (2)*. This PR caters to this use case. The way we retain user's changes is by introducing the concept of `@save` annotation/tag in JS Doc comments. If a function is marked with `@save`, no changes will be made to that function. We will update other affected functions, but the saved functions will be preserved in the updated generated code.

## Logic
1. We have 2 Typescript source files:
    a. `freshTsSourceFile`: This is the newly generated Typescript source that represents the updated OpenAPI Document
    b. `staleTsSourceFile`: The is the outdated Typescript source that was generated before the OpenAPI Document was updated
2. We walk the Typescript AST of `staleTsSourceFile`, and get a map of function names to the actual function nodes and all their JS Docs Tags. We can check whether the JS Docs Tags array has `save` or not. This will tell us whether the current function is a saved function or not. ([link](https://github.com/hasura/ndc-open-api-lambda/pull/22/files#diff-d7c2243c03130abb0392d150a0d3101e459efb5de2baf1d1c45edf5ae7bd7066))
3. We get the same map as in *step (2)* for `freshTsSourceFile`
4. We compare the ASTs using the following logic ([link](https://github.com/hasura/ndc-open-api-lambda/pull/22/files#diff-6aa219e430ceff7c6b200c0debeb0336cffbef94f11b71a7a581f1e0048fd5ad))

    *case 1:* If a saved function exists in the `freshTsSourceFile` AST: The saved function from `staleTsSourceFile` replaces the function of the same name in `freshTsSourceFile` AST.

    *case 2:* If a saved function does not exist in the `freshTsSourceFile` AST: This likely means that the corresponding API was removed from the Open API Document. However, since the function is a saved function, we add that to the `freshTsSourceFile` AST. This will however result in an error once the file is generated in the user's IDE, since that corresponding API call will likely not exist in the `api.ts` file