### PR TITLE
update readme for v0.1.0 and update nodejs lambda version to v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The OpenAPI Lambda Connector allows you to import APIs that have an OpenAPI/Swag
 
 Functions that wrap GET requests are marked with `@readonly` annotation, and are exposed as GraphQL Queries by the [NodeJS Lambda Connector](https://github.com/hasura/ndc-nodejs-lambda). All other request types are exposed as GraphQL Mutations.
 
+This Connector implements the [Data Connector Spec](https://github.com/hasura/ndc-spec)
+
+
 - [Hasura V3 Documentation](https://hasura.io/docs/3.0)
 - [NodeJS Lambda Connector](https://github.com/hasura/ndc-nodejs-lambda)
 
@@ -27,8 +30,10 @@ Functions that wrap GET requests are marked with `@readonly` annotation, and are
 
 ## Before you get Started
 
-- Please ensure that you have [downloaded and installed the DDN CLI](https://hasura.io/docs/3.0/cli/installation/).
-- Please ensure that you have Docker installed and the Docker Daemon is running.
+1. Create a [Hasura Cloud account](https://console.hasura.io)
+2. Install the [CLI](https://hasura.io/docs/3.0/cli/installation/)
+3. [Create a project](https://hasura.io/docs/3.0/getting-started/create-a-project)
+4. Please ensure that you have Docker installed and the Docker Daemon is running.
 
 ## For Hasura Users
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,18 @@ Functions that wrap GET requests are marked with `@readonly` annotation, and are
 - [Hasura V3 Documentation](https://hasura.io/docs/3.0)
 - [NodeJS Lambda Connector](https://github.com/hasura/ndc-nodejs-lambda)
 
-## Important
-
-This connector is under active development right now and is not stable. It has [known limitations](https://github.com/hasura/ndc-open-api-lambda?tab=readme-ov-file#known-limiations) and might have undocumented issues. Please create an issue if you run into any problems.
-
 ## Features
 
 - Convert Open API/swagger documentation into Typescript functions compatible with NodeJS Lambda Connector
 - Supported request types
 
-| Request Type | Query | Path | Body | Headers              |
-| ------------ | ----- | ---- | ---- | -------------------- |
-| GET          | y     | y    | NA   | Need Manual Addition |
-| POST         | y     | y    | y    | Need Manual Addition |
-| DELETE       | y     | y    | y    | Need Manual Addition |
-| PUT          | y     | y    | y    | Need Manual Addition |
-| PATCH        | y     | y    | y    | Need Manual Addition |
+| Request Type | Query | Path | Body | Headers |
+| ------------ | ----- | ---- | ---- | ------- |
+| GET          | y     | y    | NA   | y       |
+| POST         | y     | y    | y    | y       |
+| DELETE       | y     | y    | y    | y       |
+| PUT          | y     | y    | y    | y       |
+| PATCH        | y     | y    | y    | y       |
 
 ## Before you get Started
 
@@ -42,12 +38,15 @@ The Connector can be used with the DDN CLI. Use the `ddn dev` command to tell th
 
 This connector is published as a Docker Image. The image name is `ghcr.io/hasura/ndc-open-api-lambda`. The Docker Image accepts the following environment variables that can be used to alter its functionality. These variables, if present in the `ConnectorManifest` of your DDN Metadata, will be passed by the DDN CLI to the Connector.
 
-1. `NDC_OAS_DOCUMENT_URI`: The URI to your Open API Document. If you're using a file instead of a HTTP link, please ensure that it is named `swagger.json` and is present in the root directory of the volume being mounted to `/etc/connector`. This env var is nullable.
-2. `NDC_OAS_BASE_URL`: The base URL of your API. This env var is nullable.
-3. `NDC_OAS_FILE_OVERWRITE`: Boolean flag to allow previously generated files to be over-written. Defaults to `false`. Please note that the codegen will fail with an error if this is set to `false` and the files that the codegen would create already exist.
-4. `HASURA_PLUGIN_LOG_LEVEL`: The log level. Possible values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`. Defaults to `info`
-5. `NDC_OAS_LAMBDA_PRETTY_LOGS`: Boolean flag to print human readable logs instead of JSON
-6. `NDC_LAMBDA_SDK_VERSION`: NDC Lambda SDK Version to be used by the SDK. Defaults to the latest version
+1. `NDC_OAS_DOCUMENT_URI` (optional): The URI to your Open API Document. If you're using a file instead of a HTTP link, please ensure that it is named `swagger.json` and is present in the root directory of the volume being mounted to `/etc/connector`. This env var is nullable.
+2. `NDC_OAS_BASE_URL` (optional): The base URL of your API. This env var is nullable.
+3. `NDC_OAS_FILE_OVERWRITE` (optional): Boolean flag to allow previously generated files to be over-written. Defaults to `false`. Please note that the codegen will fail with an error if this is set to `false` and the files that the codegen would create already exist.
+4. `HASURA_PLUGIN_LOG_LEVEL` (optional): The log level. Possible values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`. Defaults to `info`
+5. `NDC_OAS_LAMBDA_PRETTY_LOGS` (optional): Boolean flag to print human readable logs instead of JSON. Defaults to `false`
+
+### Saving User Changes
+
+When re-running the codegen on already generated files, user changes in `functions.ts` can be preserved by adding an `@save` JS Doc Tag to the documentation comment of a function. This will ensure that that function is not overwritten and it will be added if missing in the newly generated `functions.ts`
 
 ### Usage without the DDN CLI
 
@@ -144,7 +143,6 @@ npm run watch
 - `Record<>` and `Map<>` return types are wrapped as JSON.
 - Support for [Relaxed Types](https://github.com/hasura/ndc-nodejs-lambda/tree/main?tab=readme-ov-file#relaxed-types) is a WiP.
 - [Types not supported by the NodeJS Lambda Connector](https://github.com/hasura/ndc-nodejs-lambda?tab=readme-ov-file#unsupported-types) are not supported.
-- If `*/` is present in examples or descriptions, it causes a syntax error because it denotes the end of a multi line comment in Typescript. This causes the codegen to crash. This is a high priority issue that will be fixed in upcoming releases.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This connector is published as a Docker Image. The image name is `ghcr.io/hasura
 
 ### Saving User Changes
 
-When re-running the codegen on already generated files, user changes in `functions.ts` can be preserved by adding an `@save` JS Doc Tag to the documentation comment of a function. This will ensure that that function is not overwritten and it will be added if missing in the newly generated `functions.ts`
+When re-running the codegen on already generated files, user changes in `functions.ts` can be preserved by adding an `@save` JS Doc Tag to the documentation comment of a function. This will ensure that that function is not overwritten and the saved function will be added if missing in the newly generated `functions.ts`
 
 ### Usage without the DDN CLI
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update `ghcr.io/hasura/ndc-nodejs-lambda` to version `v1.4.0` and remove env var `NDC_LAMBDA_SDK_VERSION` ([30](https://github.com/hasura/ndc-open-api-lambda/pull/30)).
 - API requests support forwarding headers that are sent to the data connector. Manual addition of headers via the `--headers` flag and `NDC_OAS_HEADERS` env var has been removed ([#28](https://github.com/hasura/ndc-open-api-lambda/pull/28)).
 - Added support for adding secruity param as a query param in `api.ts` ([#27](https://github.com/hasura/ndc-open-api-lambda/pull/27))
 - Added support for `@save` annotation to preserve user's changes ([#24](https://github.com/hasura/ndc-open-api-lambda/pull/24))

--- a/connector-definition/.hasura-connector/Dockerfile
+++ b/connector-definition/.hasura-connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hasura/ndc-nodejs-lambda:v1.2.0
+FROM ghcr.io/hasura/ndc-nodejs-lambda:v1.4.0
 
 COPY package-lock.json package.json api.ts /functions/
 

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -11,10 +11,8 @@ supportedEnvironmentVariables:
   - name: NDC_OAS_FILE_OVERWRITE
     description: "Overwrite previously generated functions.ts file and api.ts file"
     default: "false"
-  - name: NDC_LAMBDA_SDK_VERSION
-    description: "Version of the NDC Lambda SDK to be used"
 commands:
-  update: "docker run --rm -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH -e NDC_OAS_BASE_URL -e NDC_OAS_DOCUMENT_URI -e NDC_OAS_LAMBDA_PRETTY_LOGS -e NDC_OAS_FILE_OVERWRITE -e NDC_LAMBDA_SDK_VERSION -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/etc/connector ghcr.io/hasura/ndc-open-api-lambda:v0.0.2-alpha update"
+  update: "docker run --rm -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH -e NDC_OAS_BASE_URL -e NDC_OAS_DOCUMENT_URI -e NDC_OAS_LAMBDA_PRETTY_LOGS -e NDC_OAS_FILE_OVERWRITE -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/etc/connector ghcr.io/hasura/ndc-open-api-lambda:v0.0.2-alpha update"
 dockerComposeWatch:
   # Rebuild the container if a new package restore is required because package[-lock].json changed
   - path: package.json

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -44,20 +44,12 @@ Further reading:
       .env("NDC_OAS_FILE_OVERWRITE"),
   )
 
-  .addOption(
-    new Option(
-      "--ndc-lambda-sdk <version>",
-      "NDC Lambda SDK Version to be used by the SDK. Defaults to the latest version",
-    ).env("NDC_LAMBDA_SDK_VERSION"),
-  )
-
   .action((args, cmd) => {
     main(
       args.openApi,
       args.outputDirectory,
       args.overwrite === "true",
       args.baseUrl,
-      args.ndcLambdaSdk,
     );
   });
 
@@ -80,7 +72,6 @@ async function main(
   outputDir: string,
   overwrite: boolean,
   baseUrl: string | undefined,
-  ndcLambdaSdk: string | undefined,
 ) {
   context.getInstance().setOverwriteFiles(overwrite);
   context.getInstance().setOpenApiUri(openApi);


### PR DESCRIPTION
This PR does the following:
- Updates README for v0.1.0
- Update the NDC NodeJS Lambda version to v1.4.0
- Removes the ability to set NDC NodeJS Lambda version by user