### PR TITLE
Add more detailed error handling

### DIFF
--- a/templates/custom/http-client.ejs
+++ b/templates/custom/http-client.ejs
@@ -194,7 +194,10 @@ export class HttpClient<SecurityDataType = unknown> {
             r.error = (null as unknown) as E;
 
             if (!response.ok && response.status < 500) {
-              throw new hasuraSdk.UnprocessableContent("error: ", { response });
+              const data = await r.json()
+              r.data = data
+              r.error = data.error
+              throw new hasuraSdk.UnprocessableContent('error: ', { response })
             }
 
             const data = !responseFormat ? r : await response[responseFormat]()


### PR DESCRIPTION
#### Summary:
This PR refines the error handling mechanism in the `HttpClient` class by adding more detailed information to the response object when an unprocessable content error is encountered.

#### Changes:
- **Error Handling Enhancement:** 
  - The previous implementation threw an instance of `hasuraSdk.UnprocessableContent` with the raw response object, without updated `r.data` or `r.error` properties. 
  - The updated code now parses the response JSON and assigns the parsed data to the `r.data` property.
  - Additionally, the `r.error` property is now explicitly set to the `error` field from the parsed response data.
  - This ensures that the error message includes both the original response and the parsed error information.

#### Reason for Change:
The change was made to ensure that the `HttpClient` provides more informative and actionable error messages. By including the parsed response data and explicitly setting the `error` field, developers can better understand and troubleshoot issues when an unprocessable content error occurs.

#### Impact:
- **Improved Debugging:** Developers will now have access to both the raw response and parsed error information, providing a clearer context for debugging.
- **No Breaking Changes:** The change does not alter the existing API but improves the depth of information provided during error handling.

#### Example:
**Before, a user could expect something vague when encountering a downstream error:**

```json
{
  "data": null,
  "errors": [
    {
      "message": "error from data source: error: ",
      "path": [
        "getOrganizationsAllEvents"
      ],
      "extensions": {
        "details": {
          "response": {
            "data": null,
            "error": null
          }
        }
      }
    }
  ]
}
```

With this returned from the connector's logs:

```json
{"level":50,"time":1724592573423,"pid":19,"hostname":"7b2dd9f7f46b","err":{"type":"UnprocessableContent","message":"error: ","stack":"Error: error: \n    at /functions/api.ts:219:15\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async getOrganizationsAllEvents (/functions/functions.ts:15:18)\n    at async /functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:176:16\n    at async invokeFunction (/functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:172:12)\n    at async /functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:50:22","statusCode":422,"details":{"response":{"data":null,"error":null}}},"msg":"error: "}
```

**Now, a user can expect more detailed information returned via the client:**

```json
{
  "data": null,
  "errors": [
    {
      "message": "error from data source: error: ",
      "path": [
        "getOrganizationsAllEvents"
      ],
      "extensions": {
        "details": {
          "response": {
            "data": {
              "status_code": 401,
              "error_description": "The OAuth token you provided was invalid.",
              "error": "INVALID_AUTH"
            },
            "error": "INVALID_AUTH"
          }
        }
      }
    }
  ]
}
```

And via the connector's logs:

```json
{"level":50,"time":1724594442882,"pid":20,"hostname":"5baead3f680d","err":{"type":"UnprocessableContent","message":"error: ","stack":"Error: error: \n    at /functions/api.ts:222:15\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async getOrganizationsAllEvents (/functions/functions.ts:15:18)\n    at async /functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:176:16\n    at async invokeFunction (/functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:172:12)\n    at async /functions/node_modules/@hasura/ndc-lambda-sdk/src/execution.ts:50:22","statusCode":422,"details":{"response":{"data":{"status_code":401,"error_description":"The OAuth token you provided was invalid.","error":"INVALID_AUTH"},"error":"INVALID_AUTH"}}},"msg":"error: "}
```

