### PR TITLE
update connector metadata to add support for windows powershell

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add compatibilty for Windows Powershell and Command Prompt.
+- Add compatibilty for Windows Powershell and Command Prompt. ([#51](https://github.com/hasura/ndc-open-api-lambda/pull/51))
 
 - Use `hasuraSdk.JSONValue` as the type for `Record<>` and `object`. Also, make APIs that don't have a return type return `hasuraSdk.JSONValue` instead of `void` (39)[https://github.com/hasura/ndc-open-api-lambda/pull/39]
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add compatibilty for Windows Powershell and Command Prompt.
+
 - Use `hasuraSdk.JSONValue` as the type for `Record<>` and `object`. Also, make APIs that don't have a return type return `hasuraSdk.JSONValue` instead of `void` (39)[https://github.com/hasura/ndc-open-api-lambda/pull/39]
 
 ## [[0.1.1](https://github.com/hasura/ndc-open-api-lambda/releases/tag/v0.1.1)] 2024-06-05

--- a/connector-definition/.hasura-connector/connector-metadata.yaml
+++ b/connector-definition/.hasura-connector/connector-metadata.yaml
@@ -12,7 +12,13 @@ supportedEnvironmentVariables:
     description: "Overwrite previously generated functions.ts file and api.ts file"
     default: "false"
 commands:
-  update: "docker run --rm -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH -e NDC_OAS_BASE_URL -e NDC_OAS_DOCUMENT_URI -e NDC_OAS_LAMBDA_PRETTY_LOGS -e NDC_OAS_FILE_OVERWRITE -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/etc/connector ghcr.io/hasura/ndc-open-api-lambda:v0.1.1 update"
+  update:
+    type: Dockerized
+    dockerImage: ghcr.io/hasura/ndc-open-api-lambda:v0.1.1
+    commandArgs: [ "update" ]
+cliPlugin:
+  type: Docker
+  dockerImage: ghcr.io/hasura/ndc-open-api-lambda:v0.1.1
 dockerComposeWatch:
   # Rebuild the container if a new package restore is required because package[-lock].json changed
   - path: package.json

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ The NDC Open API Lambda Connector uses GitHub Releases for release management.
 
 1. Use Git Tags for release. Tags should be in the format of Semver: `vMajor.Minor.Patch`. Release branches should have the format `release/{version}`.
 2. Add this tag value to the `version` field of the CLI [here](https://github.com/hasura/ndc-open-api-lambda/blob/23976ae2459c8dd0506c7d39385d5b5bd0d1e131/src/cli/index.ts#L8)
-3. Add the tagged version of the Docker Image in the `update` command of the connector-metadata [here](https://github.com/hasura/ndc-open-api-lambda/blob/bea1d291c56093cf0caf070ddaa0af2b3e4850a3/connector-definition/.hasura-connector/connector-metadata.yaml#L17)
+3. Add the tagged version of the Docker Image in the `update` command of the connector-metadata [here](https://github.com/hasura/ndc-open-api-lambda/blob/46018a4ed5497d21a2b6941d7a690131800e41cd/connector-definition/.hasura-connector/connector-metadata.yaml#L17) and [here](https://github.com/hasura/ndc-open-api-lambda/blob/46018a4ed5497d21a2b6941d7a690131800e41cd/connector-definition/.hasura-connector/connector-metadata.yaml#L21)
 4. Update examples in the [README](./README.md)
 5. Build a cross platform Docker Image using the command `docker buildx build --platform=linux/amd64,linux/arm64 -t ghcr.io/hasura/ndc-open-api-lambda:${git-tag} .`
 6. Publish a Docker Image to GHCR with the name `ghcr.io/hasura/ndc-open-api-lambda` and the version tagged with the Git Tag using `docker push ${image:tag}`. More on [GHRC](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)


### PR DESCRIPTION
The Docker CLI Plugin Spec that adds support for Docker commands across platforms: https://github.com/hasura/ndc-hub/blob/main/rfcs/0005-docker-cli-plugin.md