### PR TITLE
fix serialization of `hasuraSdk.JSONValue`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bugfix: `hasuraSdk.JSONValue` being serialized as null ([#58](https://github.com/hasura/ndc-open-api-lambda/pull/58))
+
 ## [[0.1.4](https://github.com/hasura/ndc-open-api-lambda/releases/tag/v0.1.4)] 2024-09-12
 
 - Fix spelling ([#55](https://github.com/hasura/ndc-open-api-lambda/pull/55))

--- a/templates/custom/http-client.ejs
+++ b/templates/custom/http-client.ejs
@@ -101,7 +101,9 @@ export class HttpClient<SecurityDataType = unknown> {
     }
 
     private contentFormatters: Record<ContentType, (input: any) => any> = {
-        [ContentType.Json]: (input:any) => input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
+        [ContentType.Json]: (input: any) =>
+            (input !== null && input instanceof hasuraSdk.JSONValue) ? JSON.stringify(input.value) : 
+                (input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) :  input),
         [ContentType.Text]: (input:any) => input !== null && typeof input !== "string" ? JSON.stringify(input) : input,
         [ContentType.FormData]: (input: any) =>
             Object.keys(input || {}).reduce((formData, key) => {


### PR DESCRIPTION
`hasuraSdk.JSONValue` was not being correctly serialized, which led to API requests having empty bodies. This PR fixes the serialization