### PR TITLE
read the value of `NDC_OAS_BASE_URL` at runtime instead of build time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Read the value of `NDC_OAS_BASE_URL` at runtime instead of build time ([#66](https://github.com/hasura/ndc-open-api-lambda/pull/66))
+
 ## [[1.0.0](https://github.com/hasura/ndc-open-api-lambda/releases/tag/v1.0.0)] 2024-11-07
 
 ## [[0.2.0](https://github.com/hasura/ndc-open-api-lambda/releases/tag/v0.2.0)] 2024-09-26

--- a/templates/custom/http-client.ejs
+++ b/templates/custom/http-client.ejs
@@ -48,7 +48,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-    public baseUrl: string = "<%~ apiConfig.baseUrl %>";
+    public baseUrl: string = "";
     private securityData: SecurityDataType | null = null;
     private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
     private abortControllers = new Map<CancelToken, AbortController>();

--- a/templates/functions/functions.ejs
+++ b/templates/functions/functions.ejs
@@ -4,7 +4,7 @@ import { Api, <%~ it.importList.join(', ') %> } from './api';
 import * as hasuraSdk from "@hasura/ndc-lambda-sdk"
 
 const api = new Api({
-  baseUrl: '<%~ baseUrl %>',
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 <% for (let routeFunction of it.routeFunctions) { %>

--- a/tests/test-data/golden-files/1password
+++ b/tests/test-data/golden-files/1password
@@ -11,7 +11,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/acko-insurance
+++ b/tests/test-data/golden-files/acko-insurance
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { Api, ConsentArtifactSchema } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/adobe
+++ b/tests/test-data/golden-files/adobe
@@ -9,7 +9,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:13191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/amazon-workspaces
+++ b/tests/test-data/golden-files/amazon-workspaces
@@ -134,7 +134,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/apideck-crm
+++ b/tests/test-data/golden-files/apideck-crm
@@ -61,7 +61,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/apple-store-connect
+++ b/tests/test-data/golden-files/apple-store-connect
@@ -168,7 +168,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/atlassian-jira
+++ b/tests/test-data/golden-files/atlassian-jira
@@ -300,7 +300,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/auckland-museum
+++ b/tests/test-data/golden-files/auckland-museum
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { Api } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/aws-cloud-map
+++ b/tests/test-data/golden-files/aws-cloud-map
@@ -55,7 +55,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/azure-alerts-management
+++ b/tests/test-data/golden-files/azure-alerts-management
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { AlertRule, AlertRulePatchObject, AlertRulesList, Api } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/azure-application-insights
+++ b/tests/test-data/golden-files/azure-application-insights
@@ -8,7 +8,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/circleci
+++ b/tests/test-data/golden-files/circleci
@@ -20,7 +20,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:13191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/demo-blog-api
+++ b/tests/test-data/golden-files/demo-blog-api
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { Api, MainAuthor, MainBlog, MainBlogRequestDto } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:9191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/geomag
+++ b/tests/test-data/golden-files/geomag
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { Api } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/github
+++ b/tests/test-data/golden-files/github
@@ -246,7 +246,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/gitlab
+++ b/tests/test-data/golden-files/gitlab
@@ -63,7 +63,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/google-adsense
+++ b/tests/test-data/golden-files/google-adsense
@@ -20,7 +20,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:13191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/google-home
+++ b/tests/test-data/golden-files/google-home
@@ -38,7 +38,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:13191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/instagram
+++ b/tests/test-data/golden-files/instagram
@@ -19,7 +19,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/kubernetes
+++ b/tests/test-data/golden-files/kubernetes
@@ -146,7 +146,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:9191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/microsoft-workload-monitor
+++ b/tests/test-data/golden-files/microsoft-workload-monitor
@@ -13,7 +13,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/petstore
+++ b/tests/test-data/golden-files/petstore
@@ -2,7 +2,7 @@ import * as hasuraSdk from "@hasura/ndc-lambda-sdk";
 import { Api, ApiResponse, Order, Pet, User } from "./api";
 
 const api = new Api({
-  baseUrl: "http://localhost:13191",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/spotify
+++ b/tests/test-data/golden-files/spotify
@@ -41,7 +41,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**

--- a/tests/test-data/golden-files/trello
+++ b/tests/test-data/golden-files/trello
@@ -126,7 +126,7 @@ import {
 } from "./api";
 
 const api = new Api({
-  baseUrl: "",
+  baseUrl: `${process.env.NDC_OAS_BASE_URL}`,
 });
 
 /**


### PR DESCRIPTION
completes: https://linear.app/hasura/issue/ENT-148/openapi-connector-should-use-the-env-var-for-base-url