### PR TITLE
add null check for curSourceFile and log error if curSourceFile is null

### DIFF
--- a/src/app/parser/typescript/cleanup.ts
+++ b/src/app/parser/typescript/cleanup.ts
@@ -1,7 +1,9 @@
 import * as ts from "ts-morph";
 import * as types from "../../types";
 import * as context from "../../context";
+import * as logger from "../../../util/logger";
 import * as fs from "fs";
+import * as path from "path";
 
 export function fixImports(generatedCodeList: types.GeneratedCode[]) {
   let project: ts.Project;
@@ -23,12 +25,31 @@ export function fixImports(generatedCodeList: types.GeneratedCode[]) {
     );
   }
 
-  for (const sourceFile of project.getSourceFiles()) {
-    sourceFile.fixMissingImports().organizeImports();
+  try {
+    for (const sourceFile of project.getSourceFiles()) {
+      sourceFile.fixMissingImports().organizeImports();
 
-    const code = generatedCodeList.filter(
-      (item) => item.filePath === sourceFile.getFilePath(),
-    )[0]!;
-    code.fileContent = sourceFile.getFullText();
+      // find the source file in the generated code file list
+      let curSourceFile =
+        generatedCodeList.filter(
+          (item) => item.filePath === sourceFile.getFilePath(),
+        )[0] ??
+        // if the source file is not found by path comparison, try to find it by comparing the file name
+        generatedCodeList.filter(
+          (item) =>
+            path.basename(item.filePath) ===
+            path.basename(sourceFile.getFilePath()),
+        )[0];
+
+      if (curSourceFile) {
+        curSourceFile!.fileContent = sourceFile.getFullText();
+      } else {
+        logger.error(
+          `Error while fixing imports: Unable to find the source file for ${sourceFile.getFilePath()}\n\nSkipping import fixing and cleanup for this file`,
+        );
+      }
+    }
+  } catch (error) {
+    logger.error("Error while fixing imports. Skipping", error);
   }
 }


### PR DESCRIPTION
Fixes [ENT-226](https://linear.app/hasura/issue/ENT-226/connector-crash-reported-by-ngs-super)

An attempt at fixing the following error:
```
[02:42:41.897] FATAL (1): Cannot set properties of undefined (setting 'fileContent')
    err: {
      "type": "TypeError",
      "message": "Cannot set properties of undefined (setting 'fileContent')",
      "stack":
          TypeError: Cannot set properties of undefined (setting 'fileContent')
              at Object.fixImports (/app/dist/app/parser/typescript/cleanup.js:48:26)
              at cleanupAndFormat (/app/dist/app/writer/functions-ts-writer.js:49:13)
              at writeContentToFile (/app/dist/app/writer/functions-ts-writer.js:45:11)
              at Object.writeToFileSystem (/app/dist/app/writer/functions-ts-writer.js:35:15)
              at Object.writeToFileSystem (/app/dist/app/writer/index.js:39:31)
              at Object.runApp (/app/dist/app/index.js:45:18)
              at async main (/app/dist/cli/update.js:73:9)
    }
```

**NOTE**
I have not been able to reproduce this issue, this fix is a best case attempt by studying the crash logs