### PR TITLE
add support for `@save` in api.ts file

### DIFF
--- a/src/app/writer/index.ts
+++ b/src/app/writer/index.ts
@@ -16,7 +16,7 @@ export async function writeToFileSystem(codeToWrite: types.GeneratedCode[]) {
       (element) => element.fileType === "functions-ts",
     )[0]!;
 
-    apiWriter.writeToFileSystem(apiTsCode);
+    await apiWriter.writeToFileSystem(apiTsCode);
     await functionsWriter.writeToFileSystem(functionsTsCode, apiTsCode);
     await packageJsonWriter.writeToFileSystem();
     tsConfigWriter.writeToFileSystem();


### PR DESCRIPTION
Extend support for `@save` annotation to root level nodes in `api.ts` file