### PR TITLE
fix: handle 204 No Content without JSON parsing in http-client.ejs

### DIFF
--- a/templates/custom/http-client.ejs
+++ b/templates/custom/http-client.ejs
@@ -195,6 +195,11 @@ export class HttpClient<SecurityDataType = unknown> {
             r.data = (null as unknown) as T;
             r.error = (null as unknown) as E;
 
+            if(response.status === 204){
+                r.data = {};
+                return r;
+            }
+
             if (!response.ok && response.status < 500) {
               const data = await r.json()
               r.data = data


### PR DESCRIPTION
This ensures Hasura correctly handles "No Content" responses without attempting JSON parsing.

### Impact on existing features
No breaking changes.
No changes to golden files , code generation output is structurally identical.

### Related Issue
Fixes:  https://github.com/hasura/graphql-engine/issues/10792

### Questions
1. Do you prefer leaving the existing golden tests as are, or should I update / extend golden tests to explicitly assert 204 handling in the HTTP client layer?
2. After merging this fix, I plan to add runtime tests to the main Hasura project (`graphql-engine`) to ensure correct behavior end-to-end when calling REST APIs that return `204 No Content`. Please confirm that this is the preferred place for such tests (as opposed to keeping runtime tests in `ndc-open-api-lambda`).