### PR TITLE
ci: disable trivy vulnerability scanning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,22 +59,22 @@ jobs:
           path: ${{ env.tar_file }}
           retention-days: 1
 
-  scan-docker-image-with-trivy:
-    needs: build-docker-image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build-docker-image.outputs.tar_file }}
-
-      - name: Load Docker image
-        run: |
-          docker load -i ${{ needs.build-docker-image.outputs.tar_file }}
-      - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@v0.35.0
-        with:
-          image-ref: '${{ needs.build-docker-image.outputs.image_name }}'
-          format: 'table'
-          exit-code: 1
-          severity: 'CRITICAL,HIGH'
+#   scan-docker-image-with-trivy:
+#     needs: build-docker-image
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Download Docker image artifact
+#         uses: actions/download-artifact@v4
+#         with:
+#           name: ${{ needs.build-docker-image.outputs.tar_file }}
+# 
+#       - name: Load Docker image
+#         run: |
+#           docker load -i ${{ needs.build-docker-image.outputs.tar_file }}
+#       - name: Run Trivy vulnerability scan
+#         uses: aquasecurity/trivy-action@v0.35.0
+#         with:
+#           image-ref: '${{ needs.build-docker-image.outputs.image_name }}'
+#           format: 'table'
+#           exit-code: 1
+#           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
## Summary
- Disable Trivy vulnerability scanning steps/jobs in CI pipelines
- Trivy scan steps have been commented out from workflow/pipeline files

## Test plan
- [ ] Verify CI pipelines still run successfully without trivy steps
- [ ] Confirm no downstream jobs depend on the disabled scan steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)