### PR TITLE
ci: re-enable trivy vulnerability scanning with SHA-pinned action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,22 +59,22 @@ jobs:
           path: ${{ env.tar_file }}
           retention-days: 1
 
-#   scan-docker-image-with-trivy:
-#     needs: build-docker-image
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Download Docker image artifact
-#         uses: actions/download-artifact@v4
-#         with:
-#           name: ${{ needs.build-docker-image.outputs.tar_file }}
-# 
-#       - name: Load Docker image
-#         run: |
-#           docker load -i ${{ needs.build-docker-image.outputs.tar_file }}
-#       - name: Run Trivy vulnerability scan
-#         uses: aquasecurity/trivy-action@v0.35.0
-#         with:
-#           image-ref: '${{ needs.build-docker-image.outputs.image_name }}'
-#           format: 'table'
-#           exit-code: 1
-#           severity: 'CRITICAL,HIGH'
+  scan-docker-image-with-trivy:
+    needs: build-docker-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-docker-image.outputs.tar_file }}
+
+      - name: Load Docker image
+        run: |
+          docker load -i ${{ needs.build-docker-image.outputs.tar_file }}
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: '${{ needs.build-docker-image.outputs.image_name }}'
+          format: 'table'
+          exit-code: 1
+          severity: 'CRITICAL,HIGH'

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,13 @@ RUN npm update -g npm
 COPY ./ /app/
 WORKDIR /app/
 
-RUN npm install
+RUN npm ci
 
-# we use unsafe install because we have ignored all the test files to keep the image size small
-# the test files are not needed in the production image
-# therefore, please ensure that the tests are green before building the image
-RUN npm run install-bin-unsafe
+# Compile with dev dependencies present, then prune them so the runtime image
+# only carries production dependencies before the global CLI install.
+RUN npm run compile \
+    && npm prune --omit=dev \
+    && npm install -g .
 
 RUN mkdir /etc/connector/
 WORKDIR /etc/connector/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hasura-ndc-oas-lambda",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hasura-ndc-oas-lambda",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@npmcli/package-json": "^5.0.0",
         "commander": "^12.0.0",
@@ -15,7 +15,7 @@
         "pino-pretty": "^11.0.0",
         "prettier": "^3.2.5",
         "semver": "^7.5.4",
-        "swagger-typescript-api": "^13.0.16",
+        "swagger-typescript-api": "13.0.16",
         "ts-morph": "^22.0.0"
       },
       "bin": {
@@ -871,6 +871,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -920,6 +921,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2577,9 +2579,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -2682,18 +2684,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -3335,9 +3358,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/package.json
+++ b/package.json
@@ -42,5 +42,14 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2",
     "webpack": "^5.89.0"
+  },
+  "overrides": {
+    "@ts-morph/common": {
+      "minimatch": "9.0.7"
+    },
+    "micromatch": {
+      "picomatch": "2.3.2"
+    },
+    "lodash": "4.18.1"
   }
 }


### PR DESCRIPTION
Re-enable Trivy scanning by reverting the changes from PR #119. Pin trivy-action to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0) for security.

Co-authored-by: Poojan Savani <poojan@hasura.io>